### PR TITLE
Drops py3.6 supports, adds Docker-based development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.9.4
+FROM circleci/python:3.10.1
 
 # Install git 2.22 from source
 RUN sudo apt-get update
@@ -12,37 +12,46 @@ RUN cd /usr/src/ && \
     sudo make clean && \
     sudo rm -r /usr/src/git*
 
-# Pipx
-ENV PATH=/home/circleci/.local/bin:$PATH
-RUN pip install --user pipx
-RUN pipx install poetry
+# Poetry
+RUN sudo curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 
-# Python 3.6.13
-RUN sudo curl -O https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tgz
-RUN sudo tar -xvzf Python-3.6.13.tgz
-RUN cd Python-3.6.13 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.6.13 && sudo make
-RUN cd Python-3.6.13 && sudo make install
+# Python 3.7.12
+RUN sudo curl -O https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz && \
+    sudo tar -xvzf Python-3.7.12.tgz && \
+    cd Python-3.7.12 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.7.12
 
-# Python 3.7.10
-RUN sudo curl -O https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz
-RUN sudo tar -xvzf Python-3.7.10.tgz
-RUN cd Python-3.7.10 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.7.10 && sudo make
-RUN cd Python-3.7.10 && sudo make install
+# Python 3.8.11
+RUN sudo curl -O https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz && \
+    sudo tar -xvzf Python-3.8.11.tgz && \
+    cd Python-3.8.11 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.8.11
 
-# Python 3.8.10
-RUN sudo curl -O https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz
-RUN sudo tar -xvzf Python-3.8.10.tgz
-RUN cd Python-3.8.10 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.8.10 && sudo make
-RUN cd Python-3.8.10 && sudo make install
+# Python 3.9.10
+RUN sudo curl -O https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz && \
+    sudo tar -xvzf Python-3.9.10.tgz && \
+    cd Python-3.9.10 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.9.10
 
 RUN sudo apt-get install postgresql-client
-# Solves issues with pip
-# https://github.com/pypa/pip/issues/4924
-RUN sudo rm /usr/bin/lsb_release
 
-# Upgrade pip
-RUN pip install -U pip
-
+RUN sudo mkdir /code
+RUN sudo chmod 0777 /code
+WORKDIR /code
+ENV PATH=/code/.venv/bin:${PATH} \
+    POETRY_VIRTUALENVS_IN_PROJECT=true

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -210,9 +210,7 @@ def github_add_collaborators(
 
     github_client = GithubClient()
     collaborators_api = f'/teams/{team_id}/repos/{GITHUB_ORG_NAME}/{repo_name}'
-    github_client.put(
-        collaborators_api, json={'permission': permission}
-    )
+    github_client.put(collaborators_api, json={'permission': permission})
 
     return True
 
@@ -313,9 +311,10 @@ def circleci_configure_project_settings(repo_name):
         json={
             'feature_flags': {
                 'build-prs-only': True,
-                'autocancel-builds': True
+                'autocancel-builds': True,
             }
-        })
+        },
+    )
     resp.raise_for_status()
 
 
@@ -361,11 +360,11 @@ def temple_setup():
                     'ci/circleci: lint',
                     'ci/circleci: test',
                 ],
-                'strict': True
+                'strict': True,
             },
             'enforce_admins': False,
-            'restrictions': None
-        }
+            'restrictions': None,
+        },
     )
 
     print('Following the project on CircleCI.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
 line-length = 79
-target-version = ['py36']
+target-version = ['py37']
 skip-string-normalization = true
 

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -1,43 +1,44 @@
+{% raw -%}
 version: 2.1
 
 executors:
   python:
-    working_directory: ~/{{cookiecutter.repo_name}}
+    working_directory: /code
     docker:
       - image: opus10/circleci-public-django-app
         environment:
+          # Ensure makefile commands are not wrapped in "docker-compose run"
+          DOCKER_EXEC_WRAPPER: ''
           DATABASE_URL: postgres://root@localhost/circle_test?sslmode=disable
-      - image: circleci/postgres:11-ram
+      - image: circleci/postgres:13-ram
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: password
 
-{% raw -%}
 jobs:
   test:
     executor: python
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
-      - run: make test
+          key: v2-{{ checksum "poetry.lock" }}
+      - run: make dependencies
+      - run: make full-test-suite
       - save_cache:
-          key: v1-{{ checksum "poetry.lock" }}
+          key: v2-{{ checksum "poetry.lock" }}
           paths:
-            - /home/circleci/.local
-            - /home/circleci/.cache/pypoetry/virtualenvs
-            - /home/circleci/.cache/pipx
-            - /home/circleci/{% endraw -%}{{cookiecutter.repo_name}}{% raw -%}/.tox
+            - /home/circleci/.cache/pypoetry/
+            - /code/.venv
+            - /code/.tox
 
   lint:
     executor: python
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
+          key: v2-{{ checksum "poetry.lock" }}
+      - run: make dependencies
       - run: make lint
 
   check_changelog:
@@ -45,9 +46,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
-      - run: make check_changelog
+          key: v2-{{ checksum "poetry.lock" }}
+      - run: make dependencies
+      - run: git tidy-log origin/master..
+      - run: make tidy-lint
 
   deploy:
     executor: python
@@ -56,8 +58,8 @@ jobs:
       - run: ssh-add -D
       - run: echo "${GITHUB_DEVOPS_PRIVATE_SSH_KEY_BASE64}" | base64 --decode | ssh-add - > /dev/null
       - restore_cache:
-          key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
+          key: v2-{{ checksum "poetry.lock" }}
+      - run: make dependencies
       - run: poetry run python devops.py deploy
 
 workflows:

--- a/{{cookiecutter.repo_name}}/.env.template
+++ b/{{cookiecutter.repo_name}}/.env.template
@@ -1,1 +1,0 @@
-DATABASE_URL=postgres://postgres@localhost:5432/{{cookiecutter.module_name}}_local

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -339,3 +339,6 @@ tags
 .history
 
 # End of https://www.gitignore.io/api/vim,osx,python,django,pycharm,komodoedit,elasticbeanstalk,visualstudiocode
+
+# Ignore custom Docker compose DB data
+.db/

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
--   repo: https://github.com/ambv/black
-    rev: 21.5b1
-    hooks:
-    - id: black
-      language_version: python3.6

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -14,24 +14,53 @@ Set up your development environment with::
     cd {{cookiecutter.repo_name}}
     make setup
 
-``make setup`` will setup python managed by
-`pyenv <https://github.com/yyuu/pyenv>`_ and install dependencies using
-`poetry <https://poetry.eustace.io/>`_.
+``make setup`` will set up a development environment managed by Docker.
+Install docker `here <https://www.docker.com/get-started>`_ and be sure
+it is running when executing any of the commands below.
 
 Testing and Validation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Run the tests with::
+Run the tests on one Python version with::
 
     make test
+
+Run the full test suite against all supported Python versions with::
+
+    make full-test-suite
 
 Validate the code with::
 
     make lint
 
-Run automated code formatting with::
+If your code fails the ``black`` check, automatically format your code with::
 
     make format
+
+Committing
+~~~~~~~~~~
+
+This project uses `git-tidy <https://github.com/Opus10/git-tidy>`_ to produce structured
+commits with git trailers. Information from commit messages is used to generate release
+notes and bump the version properly.
+
+To do a structured commit with ``git-tidy``, do::
+
+    make tidy-commit
+
+All commits in a pull request must be tidy commits that encapsulate a
+change. Ideally entire features or bug fixes are encapsulated in a
+single commit. Squash all of your commits into a tidy commit with::
+
+    make tidy-squash
+
+To check if your commits pass linting, do::
+
+    make tidy-lint
+
+Note, the above command lints every commit since branching from master.
+You can also run ``make shell`` and run ``git tidy`` commands inside
+the docker environment to do other flavors of ``git tidy`` commands.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -43,13 +72,13 @@ Documentation
 The static HTML files are stored in the ``docs/_build/html`` directory.
 A shortcut for opening them (on OSX) is::
 
-    make open_docs
+    make open-docs
 
 Releases and Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Anything that is merged into the master branch will be automatically deployed
-to PyPI. Documentation will be published to a ReadTheDocs website at
+to PyPI. Documentation will be published to a ReadTheDocs at
 ``https://{{cookiecutter.repo_name}}.readthedocs.io/``.
 
 The following files will be generated and should *not* be edited by a user:

--- a/{{cookiecutter.repo_name}}/LICENSE
+++ b/{{cookiecutter.repo_name}}/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021, Opus 10
+Copyright (c) 2022, Opus 10
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -2,17 +2,17 @@
 #
 # This Makefile has the following targets:
 #
-# package_managers - Sets up python managers and python package managers
-# clean_env - Removes the virtuale env
-# dependencies - Installs all dependencies for a project
-# setup - Sets up the entire development environment and installs dependencies
-# clean_docs - Clean the documentation folder
-# clean - Clean any generated files (including documentation)
-# open_docs - Open any docs generated with "make docs"
+# setup - Sets up the development environment
+# dependencies - Installs dependencies
+# clean-docs - Clean the documentation folder
+# open-docs - Open any docs generated with "make docs"
 # docs - Generated sphinx docs
 # lint - Run code linting and static checks
 # format - Format code using black
 # test - Run tests using pytest
+# full-test-suite - Run full test suite using tox
+# shell - Run a shell in a virtualenv
+# teardown - Spin down docker resources
 
 OS = $(shell uname -s)
 
@@ -20,113 +20,105 @@ PACKAGE_NAME={{cookiecutter.repo_name}}
 MODULE_NAME={{cookiecutter.module_name}}
 SHELL=bash
 
-PY36_VERSION=3.6.13
-PY37_VERSION=3.7.10
-PY38_VERSION=3.8.10
-PY39_VERSION=3.9.4
+ifeq (${OS}, Linux)
+	DOCKER_CMD?=sudo docker
+	DOCKER_RUN_ARGS?=-v /home:/home -v $(shell pwd):/code -e DOCKER_EXEC_WRAPPER="" -u "$(shell id -u):$(shell id -g)"  -v /etc/passwd:/etc/passwd
+	# The user can be passed to docker exec commands in Linux.
+	# For example, "make shell user=root" for access to apt-get commands
+	user?=$(shell id -u)
+	group?=$(shell id ${user} -u)
+	DOCKER_EXEC_WRAPPER?=$(DOCKER_CMD) exec --user="$(user):$(group)" -it $(PACKAGE_NAME)
+else ifeq (${OS}, Darwin)
+	DOCKER_CMD?=docker
+	DOCKER_RUN_ARGS?=-v ~/:/home/circleci -v $(shell pwd):/code -e DOCKER_EXEC_WRAPPER=""
+	DOCKER_EXEC_WRAPPER?=$(DOCKER_CMD) exec -it $(PACKAGE_NAME)
+endif
+
+# Docker run mounts the local code directory, SSH (for git), and global git config information
+DOCKER_RUN_CMD?=$(DOCKER_CMD)-compose run --name $(PACKAGE_NAME) $(DOCKER_RUN_ARGS) -d app
+
 
 # Print usage of main targets when user types "make" or "make help"
+.PHONY: help
 help:
+ifndef run
 	@echo "Please choose one of the following targets: \n"\
-	      "    setup: Setup development environment and install dependencies\n"\
+	      "    setup: Setup development environment\n"\
+	      "    lock: Lock dependencies\n"\
+	      "    dependencies: Install dependencies\n"\
+	      "    shell: Start a shell\n"\
 	      "    test: Run tests\n"\
+	      "    tox: Run tests against all versions of Python\n"\
 	      "    lint: Run code linting and static checks\n"\
+	      "    format: Format code using Black\n"\
 	      "    docs: Build Sphinx documentation\n"\
-	      "    open_docs: Open built documentation\n"\
+	      "    open-docs: Open built documentation\n"\
+	      "    teardown: Spin down docker resources\n"\
 	      "\n"\
 	      "View the Makefile for more documentation"
 	@exit 2
-
-
-# Utility to verify we arent in a virtualenv
-.PHONY: check_not_inside_venv
-check_not_inside_venv:
-ifeq (${OS}, Darwin)
-	which pip | grep -q ".pyenv" || (echo "Please deactivate your virtualenv and try again" && exit 1)
+else
+	$(DOCKER_EXEC_WRAPPER) $(run)
 endif
 
 
-# Sets up pyenv, poetry, and any other package/language managers (e.g. NPM)
-.PHONY: package_managers
-package_managers: check_not_inside_venv
-ifeq (${OS}, Darwin)
-# Install pyenv and ensure we remain up to date with pyenv so that new python
-# versions are available for installation
-	-brew install pyenv 2> /dev/null
-	-brew upgrade pyenv 2> /dev/null
-	-pyenv rehash
-	pyenv install -s --patch ${PY36_VERSION} < <(curl -sSL https://github.com/python/cpython/commit/8ea6353.patch)
-	pyenv install -s --patch ${PY37_VERSION}
-	pyenv install -s --patch ${PY38_VERSION}
-	pyenv install -s --patch ${PY39_VERSION}
-	pyenv local ${PY36_VERSION} ${PY37_VERSION} ${PY38_VERSION} ${PY39_VERSION}
-endif
-# Conditionally install pipx so that we can globally install poetry
-	pip install --user --upgrade --force-reinstall pipx
-	pipx ensurepath
-	-pipx install --force poetry --pip-args="--upgrade"
+# Ensure we are logged into the Gitlab docker registry and start a detached container
+.PHONY: docker-start
+docker-start:
+	$(DOCKER_CMD) pull opus10/circleci-public-django-app
+	$(DOCKER_RUN_CMD)
 
 
-# Builds all dependencies for a project
+# Lock dependencies
+.PHONY: lock
+lock:
+	$(DOCKER_EXEC_WRAPPER) poetry lock --no-update
+
+
+# Install dependencies
 .PHONY: dependencies
 dependencies:
-	poetry install
+	$(DOCKER_EXEC_WRAPPER) poetry install
 
 
-.PHONY: git_tidy
-git_tidy:
-	-pipx install --force git-tidy --pip-args="--upgrade"
-	git tidy --template -o .gitcommit.tpl
-	git config --local commit.template .gitcommit.tpl
-
-
-.PHONY: pre_commit
-pre_commit:
-	poetry run pre-commit install
-
-
-# Sets up the database and the environment files for the first time
-.PHONY: db_and_env_setup
-db_and_env_setup:
-ifeq (${OS}, Darwin)
-	-brew install postgresql 2> /dev/null
-	brew services start postgresql
-endif
-	-psql postgres -c "CREATE USER postgres;"
-	-psql postgres -c "ALTER USER postgres SUPERUSER;"
-	-psql postgres -c "CREATE DATABASE ${MODULE_NAME}_local OWNER postgres;"
-	-psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE ${MODULE_NAME}_local to postgres;"
-	-cp -n .env.template .env
-
-
-.PHONY: ci_setup
-ci_setup: package_managers git_tidy db_and_env_setup dependencies
-
-
-# Sets up environment and installs dependencies
+# Sets up development environment
 .PHONY: setup
-setup: check_not_inside_venv package_managers git_tidy db_and_env_setup dependencies pre_commit
+setup: teardown docker-start lock dependencies
+	$(DOCKER_EXEC_WRAPPER) git tidy --template -o .gitcommit.tpl
+	$(DOCKER_EXEC_WRAPPER) git config --local commit.template .gitcommit.tpl
+
+
+# Run a shell
+.PHONY: shell
+shell:
+	$(DOCKER_EXEC_WRAPPER) /bin/bash
+
+
+# Run pytest
+.PHONY: test
+test:
+	$(DOCKER_EXEC_WRAPPER) pytest
+
+
+# Run full test suite
+.PHONY: full-test-suite
+full-test-suite:
+	$(DOCKER_EXEC_WRAPPER) tox
 
 
 # Clean the documentation folder
-.PHONY: clean_docs
-clean_docs:
-	-cd docs && poetry run make clean
-
-
-# Clean any auto-generated files
-.PHONY: clean
-clean: clean_docs clean_env
-	rm -rf dist/*
-	rm -rf coverage .coverage .coverage*
-	rm -rf .venv
+.PHONY: clean-docs
+clean-docs:
+	-$(DOCKER_EXEC_WRAPPER) bash -c 'cd docs && make clean'
 
 
 # Open the build docs (only works on Mac)
-.PHONY: open_docs
-open_docs:
+.PHONY: open-docs
+open-docs:
 ifeq (${OS}, Darwin)
 	open docs/_build/html/index.html
+else ifeq (${OS}, Linux)
+	xdg-open docs/_build/html/index.html
 else
 	@echo "Open 'docs/_build/html/index.html' to view docs"
 endif
@@ -134,44 +126,44 @@ endif
 
 # Build Sphinx autodocs
 .PHONY: docs
-docs: clean_docs  # Ensure docs are clean, otherwise weird render errors can result
-	cd docs && poetry run make html
+docs: clean-docs  # Ensure docs are clean, otherwise weird render errors can result
+	$(DOCKER_EXEC_WRAPPER) bash -c 'cd docs && make html'
 
 
-# Run code linting and static analysis
+# Run code linting and static analysis. Ensure docs can be built
 .PHONY: lint
 lint:
-	poetry run black . --check
-	poetry run flake8 -v ${MODULE_NAME}/
-	poetry run temple update --check
-	poetry run make docs  # Ensure docs can be built during validation
+	$(DOCKER_EXEC_WRAPPER) black . --check
+	$(DOCKER_EXEC_WRAPPER) flake8 -v ${MODULE_NAME}
+	$(DOCKER_EXEC_WRAPPER) temple update --check
+	$(DOCKER_EXEC_WRAPPER) bash -c 'cd docs && make html'
 
 
-# Lint commit messages and show changelog when on circleci
-check_changelog:
-ifdef CIRCLECI
-	git tidy-log origin/master..
-endif
-	git tidy-lint origin/master
+# Lint commit messages
+.PHONY: tidy-lint
+tidy-lint:
+	$(DOCKER_EXEC_WRAPPER) git tidy-lint origin/master..
 
 
-# Format code
+# Perform a tidy commit
+.PHONY: tidy-commit
+tidy-commit:
+	$(DOCKER_EXEC_WRAPPER) git tidy-commit
+
+
+# Perform a tidy squash
+.PHONY: tidy-squash
+tidy-squash:
+	$(DOCKER_EXEC_WRAPPER) git tidy-squash origin/master
+
+
+# Format code with black
+.PHONY: format
 format:
-	poetry run black .
+	$(DOCKER_EXEC_WRAPPER) black .
 
 
-# Run tests
-.PHONY: test
-test:
-	poetry run tox
-
-
-# Show the version and name of the project
-.PHONY: version
-version:
-	-@poetry version | rev | cut -f 1 -d' ' | rev
-
-
-.PHONY: project_name
-project_name:
-	-@poetry version | cut -d' ' -f1
+# Spin down docker resources
+.PHONY: teardown
+teardown:
+	$(DOCKER_CMD)-compose down

--- a/{{cookiecutter.repo_name}}/devops.py
+++ b/{{cookiecutter.repo_name}}/devops.py
@@ -98,7 +98,7 @@ def _find_sem_ver_update():
 def _update_package_version():
     """Apply semantic versioning to package based on git commit messages"""
     # Obtain the current version
-    old_version = _shell_stdout('make version')
+    old_version = _shell_stdout("poetry version | rev | cut -f 1 -d' ' | rev")
     if old_version == '0.0.0':
         old_version = ''
     latest_tag = _find_latest_tag()
@@ -114,7 +114,7 @@ def _update_package_version():
     _shell(f'poetry version {sem_ver}')
 
     # Get the new version
-    new_version = _shell_stdout('make version')
+    new_version = _shell_stdout("poetry version | rev | cut -f 1 -d' ' | rev")
 
     if new_version == old_version:
         raise RuntimeError(

--- a/{{cookiecutter.repo_name}}/docker-compose.yml
+++ b/{{cookiecutter.repo_name}}/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.3"
+   
+services:
+  db:
+    image: postgres:13
+    volumes:
+      - ./.db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_NAME=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  app:
+    image: opus10/circleci-public-django-app
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+    depends_on:
+      - db

--- a/{{cookiecutter.repo_name}}/docs/_static/css/custom.css
+++ b/{{cookiecutter.repo_name}}/docs/_static/css/custom.css
@@ -1,5 +1,0 @@
-/* Temporary fix for https://github.com/rtfd/sphinx_rtd_theme/issues/417 */
-
-.rst-content .highlight > pre {
-    line-height: 18px;
-}

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -77,7 +77,7 @@ default_role = 'any'
 
 # General information about the project.
 project = u'{{cookiecutter.repo_name}}'
-copyright = u'2021, Opus 10'
+copyright = u'2022, Opus 10'
 author = u'Opus 10 Engineering'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -126,7 +126,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------
@@ -158,7 +158,7 @@ latex_elements = {
 latex_documents = [
     (
         master_doc,
-        'cookiecutterrepo_name.tex',
+        '{{cookiecutter.repo_name}}.tex',
         u'{{cookiecutter.repo_name}} Documentation',
         u'Opus 10',
         'manual',
@@ -173,7 +173,7 @@ latex_documents = [
 man_pages = [
     (
         master_doc,
-        'cookiecutterrepo_name',
+        '{{cookiecutter.repo_name}}',
         u'{{cookiecutter.repo_name}} Documentation',
         [author],
         1,
@@ -189,18 +189,14 @@ man_pages = [
 texinfo_documents = [
     (
         master_doc,
-        'cookiecutterrepo_name',
+        '{{cookiecutter.repo_name}}',
         u'{{cookiecutter.repo_name}} Documentation',
         author,
-        'cookiecutterrepo_name',
-        'One line description of project.',
+        '{{cookiecutter.repo_name}}',
+        '{{cookiecutter.short_description}}',
         'Miscellaneous',
     )
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
-
-
-def setup(app):
-    app.add_css_file('css/custom.css')

--- a/{{cookiecutter.repo_name}}/manage.py
+++ b/{{cookiecutter.repo_name}}/manage.py
@@ -2,12 +2,6 @@
 import os
 import sys
 
-import dotenv
-
-
-# Read the environment from a .env file
-dotenv.load_dotenv()
-
 
 if __name__ == "__main__":
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,11 +1,26 @@
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.1.13"]
 build-backend = "poetry.masonry.api"
 
 [tool.black]
-line-length = 79
-target-version = ['py36']
+line-length = 99
+target-version = ['py37']
 skip-string-normalization = true
+
+[tool.coverage.run]
+branch = true
+source = ["{{cookiecutter.module_name}}"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "pass",
+    "pytest.mark.skip"
+]
+show_missing = true
+fail_under = 100
 
 [tool.poetry]
 name = "{{cookiecutter.repo_name}}"
@@ -19,10 +34,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3 :: Only",
   "Framework :: Django",
 ]
@@ -33,29 +48,37 @@ repository = "https://github.com/Opus10/{{cookiecutter.repo_name}}"
 documentation = "https://{{cookiecutter.repo_name}}.readthedocs.io"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4"
+python = ">=3.7.0,<4"
 django = ">=2"
 
 [tool.poetry.dev-dependencies]
 black = "21.5b1"
 dj-database-url = "0.5.0"
 flake8 = "3.9.2"
-flake8-bugbear = "21.4.3"
-flake8-comprehensions = "3.5.0"
+flake8-bugbear = "22.1.11"
+flake8-comprehensions = "3.8.0"
 flake8-import-order = "0.18.1"
 flake8-logging-format = "0.6.0"
 flake8-mutable = "1.2.0"
-packaging = "19.2"
+git-tidy = "1.1.2"
+packaging = ">=19.2"
 pip = "*"
 pre-commit = "2.13.0"
-psycopg2-binary = "2.8.6"
-pytest = "6.2.4"
-pytest-cov = "2.12.0"
+psycopg2-binary = "2.9.3"
+pytest = "7.0.0"
+pytest-cov = "3.0.0"
 pytest-dotenv = "0.5.2"
-pytest-django = "4.3.0"
+pytest-django = "4.5.2"
 requests = "2.25.1"
-Sphinx = "4.0.2"
-sphinx-rtd-theme = "0.5.2"
+Sphinx = "4.4.0"
+sphinx-rtd-theme = "1.0.0"
 temple = "*"
-tox = "3.23.1"
+tox = "3.24.5"
 zipp = "3.4.1"
+
+[tool.pytest.ini_options]
+xfail_strict = true
+addopts = "--reuse-db"
+testpaths = "{{cookiecutter.module_name}}/tests"
+norecursedirs = ".venv"
+DJANGO_SETTINGS_MODULE = "settings"

--- a/{{cookiecutter.repo_name}}/settings.py
+++ b/{{cookiecutter.repo_name}}/settings.py
@@ -9,3 +9,5 @@ INSTALLED_APPS = [
 ]
 # Database url comes from the DATABASE_URL env var
 DATABASES = {'default': dj_database_url.config()}
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,20 +1,3 @@
-[coverage:run]
-branch = True
-source = {{cookiecutter.module_name}}
-
-[coverage:report]
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # Don't cover defensive assertion code
-    raise AssertionError
-    raise NotImplementedError
-
-    # Lexical noop
-    pass
-show_missing = 1
-
 [flake8]
 ignore =
     W503,
@@ -23,10 +6,3 @@ application-import-names = {{cookiecutter.module_name}},tests
 import-order-style = google
 max-complexity = 10
 max-line-length = 99
-
-[tool:pytest]
-xfail_strict = true
-addopts = --reuse-db
-norecursedirs = .venv
-DJANGO_SETTINGS_MODULE = settings
-env_files = .env.template

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,31 +1,30 @@
 [tox]
 isolated_build = true
-envlist = clean,py{36,37,38,39}-django{22,30,31,32},report
+envlist = clean,py37-django22,py37-django32,{38,39,310}-django{22,32,40},report
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
 whitelist_externals =
   poetry
   bash
 passenv = DATABASE_URL
 skip_install = true
 commands =
-    bash -c 'poetry export --dev --without-hashes -f requirements.txt | grep -v "^[dD]jango==" | poetry run pip install --no-deps -r /dev/stdin'
-    poetry run pytest --cov --cov-append --cov-config setup.cfg {{cookiecutter.module_name}}/
+    bash -c 'poetry export --dev --without-hashes -f requirements.txt | grep -v "^[dD]jango==" | pip install --no-deps -r /dev/stdin'
+    pytest --cov --cov-fail-under=0 --cov-append {{cookiecutter.module_name}}/
 
 [testenv:report]
 whitelist_externals =
   poetry
 skip_install = true
 commands =
-    poetry run coverage report --fail-under 100
+    coverage report --fail-under 100
 
 [testenv:clean]
 whitelist_externals =
   poetry
 skip_install = true
-commands = poetry run coverage erase
+commands = coverage erase


### PR DESCRIPTION
Drops Python 3.6 support and adds Python 3.10 support. Also tests against Django 4.

This version of the template also rewrites the Makefile and Contrbuting guide to be
Docker-based. Developers only need to install Docker to run the test suite, do linting, and
perform other core development commands.