### PR TITLE
Add Django 5.0 support

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Compatibility
 
-`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.
 
 ## Documentation
 

--- a/{{ cookiecutter.repo_name }}/docs/index.md
+++ b/{{ cookiecutter.repo_name }}/docs/index.md
@@ -4,4 +4,4 @@ Welcome to the docs for `{{ cookiecutter.repo_name }}`! It doesn't appear that t
 
 ## Compatibility
 
-`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12, Django 3.2 - 4.2, Psycopg 2 - 3, and Postgres 12 - 16.
+`{{ cookiecutter.repo_name }}` is compatible with Python 3.8 - 3.12, Django 3.2 - 5.0, Psycopg 2 - 3, and Postgres 12 - 16.

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
   "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{38,39,310,311,312}-django42-psycopg2
     py312-django42-psycopg3
     py{310,311,312}-django50-psycopg2
-    py312-django42-psycopg3
+    py312-django50-psycopg3
     report
 
 [testenv]

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -1,12 +1,19 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310,311,312}-django{32,42}-psycopg2,py312-django42-psycopg3,report
+envlist =
+    py{38,39,310,311,312}-django32-psycopg2
+    py{38,39,310,311,312}-django42-psycopg2
+    py312-django42-psycopg3
+    py{310,311,312}-django50-psycopg2
+    py312-django42-psycopg3
+    report
 
 [testenv]
 install_command = pip install {opts} --no-compile {packages}
 deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0rc1,<5.1
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]
 allowlist_externals =


### PR DESCRIPTION
Adapted from the changes in https://github.com/Opus10/django-pghistory/pull/107 andhttps://github.com/Opus10/django-pgtrigger/pull/138 from @pfouque.

I looked back at #5 and e657b058113b0c30f955c3f65cd09b779eab6c3a for any other possible changes, didn’t spot any.