### PR TITLE
Pass positional arguments through tox to pytest

### DIFF
--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -20,7 +20,7 @@ skip_install = true
 commands =
     bash -c 'poetry export --with dev --without-hashes -f requirements.txt | grep -v "^[dD]jango==" | grep -v "^psycopg2-binary==" | pip install --no-compile -q --no-deps -r /dev/stdin'
     pip install --no-compile -q --no-deps --no-build-isolation -e .
-    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml {{ cookiecutter.module_name }}/
+    pytest --create-db --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml {posargs}
 
 [testenv:report]
 allowlist_externals =


### PR DESCRIPTION
Per: https://tox.wiki/en/latest/config.html#substitutions-for-positional-arguments-in-commands

This enables local test runs of a single test like:

```
$ tox -e py312-django42-psycopg3 -- -k test_post
```

…which I just successfully ran in django-pghistory after making this modification.